### PR TITLE
Add Windows-style artwork gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Artwork Gallery</title>
+  <link rel="stylesheet" href="windows.css">
+</head>
+<body>
+  <div class="window">
+    <div class="title-bar">
+      <div class="title-bar-text">Artwork Gallery</div>
+      <div class="title-bar-controls">
+        <button aria-label="Minimize"></button>
+        <button aria-label="Maximize"></button>
+        <button aria-label="Close"></button>
+      </div>
+    </div>
+    <div class="window-body">
+      <div class="gallery">
+        <figure>
+          <img src="images/art1.jpg" alt="Artwork 1">
+          <figcaption>Artwork 1</figcaption>
+        </figure>
+        <figure>
+          <img src="images/art2.jpg" alt="Artwork 2">
+          <figcaption>Artwork 2</figcaption>
+        </figure>
+        <figure>
+          <img src="images/art3.jpg" alt="Artwork 3">
+          <figcaption>Artwork 3</figcaption>
+        </figure>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/windows.css
+++ b/windows.css
@@ -1,0 +1,63 @@
+body {
+  background: #008080;
+  font-family: 'MS Sans Serif', 'Segoe UI', sans-serif;
+  margin: 0;
+}
+
+.window {
+  width: 80%;
+  max-width: 800px;
+  margin: 40px auto;
+  border: 2px solid #000;
+  box-shadow: -1px -1px 0 #fff, 1px 1px 0 #808080, -2px -2px 0 #dfdfdf, 2px 2px 0 #000;
+  background: #C0C0C0;
+}
+
+.title-bar {
+  background: linear-gradient(90deg, #000080, #1084d0);
+  color: #fff;
+  padding: 2px 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: bold;
+}
+
+.title-bar-controls button {
+  width: 16px;
+  height: 14px;
+  margin-left: 2px;
+  border: none;
+  background: #C0C0C0;
+  box-shadow: -1px -1px 0 #fff, 1px 1px 0 #808080;
+  padding: 0;
+}
+
+.window-body {
+  padding: 10px;
+}
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.gallery figure {
+  margin: 0;
+  padding: 2px;
+  border: 2px solid #fff;
+  background: #C0C0C0;
+  box-shadow: 1px 1px 0 #808080, -1px -1px 0 #fff;
+}
+
+.gallery img {
+  width: 100%;
+  display: block;
+}
+
+.gallery figcaption {
+  text-align: center;
+  font-size: 0.9rem;
+  margin-top: 4px;
+}


### PR DESCRIPTION
## Summary
- create HTML page displaying artworks with classic Windows UI styling
- add CSS mimicking Windows 95 look and placeholder images folder

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bff9fb2964832f93b0d59b51d7a413