### PR TITLE
Add Start menu and draggable gallery window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # artworkwindows
-display artwork through old windows UI
+
+Static web page that showcases artwork thumbnails inside a nostalgic
+Windows™-95 style interface. A Start menu opens the gallery window and
+the window itself can be dragged around the teal desktop. Artwork images
+and metadata are loaded at runtime from the [artwork-snake](https://github.com/dannybellieveit/artwork-snake)
+repository so no binary assets are stored here.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Artwork Gallery</title>
+  <link rel="stylesheet" href="windows.css">
+  <script src="https://raw.githubusercontent.com/dannybellieveit/artwork-snake/main/public/images-data.js"></script>
+</head>
+<body>
+  <div class="window" id="galleryWindow" style="display:none;">
+    <div class="title-bar">
+      <div class="title-bar-text">Artwork Gallery</div>
+      <div class="title-bar-controls">
+        <button aria-label="Minimize"></button>
+        <button aria-label="Maximize"></button>
+        <button aria-label="Close"></button>
+      </div>
+    </div>
+    <div class="window-body">
+      <div class="gallery"></div>
+    </div>
+  </div>
+
+  <div class="start-menu hidden" id="startMenu">
+    <ul>
+      <li id="openGallery">Artwork Gallery</li>
+    </ul>
+  </div>
+
+  <div class="taskbar">
+    <button class="start-button" id="startBtn">Start</button>
+    <div class="taskbar-item" id="galleryTab" style="display:none;">Gallery</div>
+  </div>
+
+  <script>
+    const gallery = document.querySelector('.gallery');
+    const baseUrl = 'https://raw.githubusercontent.com/dannybellieveit/artwork-snake/main/public/';
+    if (Array.isArray(window.imagesData)) {
+      window.imagesData.forEach(({ src, title, artist, spotifyUrl }) => {
+        const fig = document.createElement('figure');
+        const img = document.createElement('img');
+        img.src = baseUrl + src;
+        img.alt = title;
+        const cap = document.createElement('figcaption');
+        const link = document.createElement('a');
+        link.href = spotifyUrl;
+        link.textContent = `${title} – ${artist}`;
+        link.target = '_blank';
+        cap.appendChild(link);
+        fig.appendChild(img);
+        fig.appendChild(cap);
+        gallery.appendChild(fig);
+      });
+    }
+
+    const startBtn = document.getElementById('startBtn');
+    const startMenu = document.getElementById('startMenu');
+    const galleryWindow = document.getElementById('galleryWindow');
+    const galleryTab = document.getElementById('galleryTab');
+
+    startBtn.addEventListener('click', () => {
+      startMenu.classList.toggle('hidden');
+    });
+
+    document.getElementById('openGallery').addEventListener('click', () => {
+      galleryWindow.style.display = 'block';
+      galleryTab.style.display = 'inline-block';
+      startMenu.classList.add('hidden');
+    });
+
+    const titleBar = galleryWindow.querySelector('.title-bar');
+    let offsetX = 0, offsetY = 0, isDown = false;
+
+    titleBar.addEventListener('mousedown', (e) => {
+      isDown = true;
+      offsetX = e.clientX - galleryWindow.offsetLeft;
+      offsetY = e.clientY - galleryWindow.offsetTop;
+    });
+
+    document.addEventListener('mouseup', () => {
+      isDown = false;
+    });
+
+    document.addEventListener('mousemove', (e) => {
+      if (!isDown) return;
+      galleryWindow.style.left = `${e.clientX - offsetX}px`;
+      galleryWindow.style.top = `${e.clientY - offsetY}px`;
+    });
+
+    const closeBtn = galleryWindow.querySelector('button[aria-label="Close"]');
+    closeBtn.addEventListener('click', () => {
+      galleryWindow.style.display = 'none';
+      galleryTab.style.display = 'none';
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Artwork Gallery</title>
   <link rel="stylesheet" href="windows.css">
-  <script src="https://raw.githubusercontent.com/dannybellieveit/artwork-snake/main/public/images-data.js"></script>
 </head>
 <body>
   <div class="window" id="galleryWindow" style="display:none;">
@@ -36,23 +35,32 @@
   <script>
     const gallery = document.querySelector('.gallery');
     const baseUrl = 'https://raw.githubusercontent.com/dannybellieveit/artwork-snake/main/public/';
-    if (Array.isArray(window.imagesData)) {
-      window.imagesData.forEach(({ src, title, artist, spotifyUrl }) => {
-        const fig = document.createElement('figure');
-        const img = document.createElement('img');
-        img.src = baseUrl + src;
-        img.alt = title;
-        const cap = document.createElement('figcaption');
-        const link = document.createElement('a');
-        link.href = spotifyUrl;
-        link.textContent = `${title} – ${artist}`;
-        link.target = '_blank';
-        cap.appendChild(link);
-        fig.appendChild(img);
-        fig.appendChild(cap);
-        gallery.appendChild(fig);
-      });
-    }
+
+    fetch(baseUrl + 'images-data.js')
+      .then(res => res.text())
+      .then(text => {
+        const script = document.createElement('script');
+        script.textContent = text;
+        document.head.appendChild(script);
+        if (Array.isArray(window.imagesData)) {
+          window.imagesData.forEach(({ src, title, artist, spotifyUrl }) => {
+            const fig = document.createElement('figure');
+            const img = document.createElement('img');
+            img.src = baseUrl + src;
+            img.alt = title;
+            const cap = document.createElement('figcaption');
+            const link = document.createElement('a');
+            link.href = spotifyUrl;
+            link.textContent = `${title} – ${artist}`;
+            link.target = '_blank';
+            cap.appendChild(link);
+            fig.appendChild(img);
+            fig.appendChild(cap);
+            gallery.appendChild(fig);
+          });
+        }
+      })
+      .catch(err => console.error('Failed to load images:', err));
 
     const startBtn = document.getElementById('startBtn');
     const startMenu = document.getElementById('startMenu');

--- a/windows.css
+++ b/windows.css
@@ -1,0 +1,155 @@
+body {
+  background: #008080;
+  font-family: 'MS Sans Serif', 'Segoe UI', sans-serif;
+  margin: 0;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.hidden {
+  display: none;
+}
+
+.window {
+  position: absolute;
+  top: 60px;
+  left: 40px;
+  width: 600px;
+  border: 2px solid #000;
+  box-shadow: -1px -1px 0 #fff, 1px 1px 0 #808080,
+              -2px -2px 0 #dfdfdf, 2px 2px 0 #000;
+  background: #C0C0C0;
+}
+
+.title-bar {
+  background: linear-gradient(90deg, #000080, #1084d0);
+  color: #fff;
+  padding: 2px 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: bold;
+  cursor: move;
+}
+
+.title-bar-controls button {
+  width: 16px;
+  height: 14px;
+  margin-left: 2px;
+  border: none;
+  padding: 0;
+  background: #C0C0C0;
+  box-shadow: -1px -1px 0 #fff, 1px 1px 0 #808080;
+}
+
+.title-bar-controls button:active {
+  box-shadow: inset 1px 1px 0 #000;
+}
+
+.title-bar-controls button[aria-label="Minimize"]::before {
+  content: "_";
+  position: relative;
+  top: -3px;
+}
+
+.title-bar-controls button[aria-label="Maximize"]::before {
+  content: "\25A1";
+  font-size: 12px;
+}
+
+.title-bar-controls button[aria-label="Close"]::before {
+  content: "\00D7";
+  font-size: 14px;
+}
+
+.window-body {
+  padding: 10px;
+  background: #C0C0C0;
+}
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.gallery figure {
+  margin: 0;
+  padding: 2px;
+  border: 2px solid #fff;
+  background: #C0C0C0;
+  box-shadow: 1px 1px 0 #808080, -1px -1px 0 #fff;
+}
+
+.gallery img {
+  width: 100%;
+  display: block;
+}
+
+.gallery figcaption {
+  text-align: center;
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.taskbar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 32px;
+  background: #C0C0C0;
+  border-top: 2px solid #fff;
+  box-shadow: inset 0 1px 0 #808080, inset 0 -1px 0 #fff;
+  display: flex;
+  align-items: center;
+}
+
+.start-button {
+  margin: 2px;
+  padding: 2px 10px;
+  font-weight: bold;
+  background: #C0C0C0;
+  border: 2px solid;
+  border-color: #fff #808080 #808080 #fff;
+  box-shadow: inset -1px -1px 0 #fff, inset 1px 1px 0 #808080;
+}
+
+.start-button:active {
+  border-color: #808080 #fff #fff #808080;
+  box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080;
+}
+
+.taskbar-item {
+  margin: 2px;
+  padding: 2px 8px;
+  background: #C0C0C0;
+  border: 2px solid;
+  border-color: #fff #808080 #808080 #fff;
+  box-shadow: inset -1px -1px 0 #fff, inset 1px 1px 0 #808080;
+}
+
+.start-menu {
+  position: fixed;
+  bottom: 32px;
+  left: 0;
+  width: 200px;
+  background: #C0C0C0;
+  border: 2px solid #000;
+  box-shadow: -1px -1px 0 #fff, 1px 1px 0 #808080;
+}
+
+.start-menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+}
+
+.start-menu li {
+  padding: 2px 4px;
+}
+
+.start-menu li:hover {
+  background: #000080;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add Start menu and taskbar item for artwork gallery
- make artwork window draggable for a more authentic Windows 95 feel
- document nostalgic interface and remote image loading in README
- load gallery images and metadata from the artwork-snake repo at runtime to avoid storing binaries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bff9fb2964832f93b0d59b51d7a413