### PR TITLE
Enhance Windows-style gallery window

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,14 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>Artwork Gallery</title>
   <link rel="stylesheet" href="windows.css">
 </head>
 <body>
-codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
   <div class="window" id="galleryWindow" style="display:none;">
 
     <div class="title-bar">
@@ -21,7 +19,6 @@ codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
       </div>
     </div>
     <div class="window-body">
-codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
       <div class="gallery"></div>
     </div>
   </div>
@@ -33,7 +30,9 @@ codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
   </div>
 
   <div class="taskbar">
-    <button class="start-button" id="startBtn">Start</button>
+    <button class="start-button" id="startBtn">
+      <img src="https://win98icons.alexmeub.com/icons/png/start.png" alt="" class="start-icon">Start
+    </button>
     <div class="taskbar-item" id="galleryTab" style="display:none;">Gallery</div>
   </div>
 
@@ -111,6 +110,19 @@ codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
     closeBtn.addEventListener('click', () => {
       galleryWindow.style.display = 'none';
       galleryTab.style.display = 'none';
+    });
+
+    const minimizeBtn = galleryWindow.querySelector('button[aria-label="Minimize"]');
+    minimizeBtn.addEventListener('click', () => {
+      galleryWindow.style.display = 'none';
+    });
+
+    galleryTab.addEventListener('click', () => {
+      if (galleryWindow.style.display === 'none') {
+        galleryWindow.style.display = 'block';
+      } else {
+        galleryWindow.style.display = 'none';
+      }
     });
   </script>
 

--- a/windows.css
+++ b/windows.css
@@ -2,9 +2,9 @@ body {
   background: #008080;
   font-family: 'MS Sans Serif', 'Segoe UI', sans-serif;
   margin: 0;
-codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
   height: 100vh;
   overflow: hidden;
+  cursor: default;
 }
 
 .hidden {
@@ -31,7 +31,6 @@ codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
   justify-content: space-between;
   align-items: center;
   font-weight: bold;
- codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
   cursor: move;
 
 }
@@ -41,7 +40,6 @@ codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
   height: 14px;
   margin-left: 2px;
   border: none;
-codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
   padding: 0;
   background: #C0C0C0;
   box-shadow: -1px -1px 0 #fff, 1px 1px 0 #808080;
@@ -70,9 +68,9 @@ codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
 
 .window-body {
   padding: 10px;
-codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
-  background: #C0C0C0;
-
+  background: #fff;
+  height: 400px;
+  overflow: auto;
 }
 
 .gallery {
@@ -99,7 +97,6 @@ codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
   font-size: 0.9rem;
   margin-top: 4px;
 }
- codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
 
 .taskbar {
   position: fixed;
@@ -122,6 +119,14 @@ codex/create-html-page-for-artworks-in-windows-ui-style-lacf8m
   border: 2px solid;
   border-color: #fff #808080 #808080 #fff;
   box-shadow: inset -1px -1px 0 #fff, inset 1px 1px 0 #808080;
+  display: flex;
+  align-items: center;
+}
+
+.start-button .start-icon {
+  width: 20px;
+  height: 20px;
+  margin-right: 4px;
 }
 
 .start-button:active {


### PR DESCRIPTION
## Summary
- Clean up stray text and add Windows-like start button icon
- Make gallery window scrollable with classic UI styling
- Add minimize/taskbar toggle for a more authentic window experience
- Load start button icon from external source to avoid storing binary assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c02a41c55c832f9f7ead1c640dc6c3