### PR TITLE
chore: rename wrangler project

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ Deploy to Cloudflare with:
 ```
 npm run deploy
 ```
+
+This uses `wrangler pages deploy .` under the hood to publish the site.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "echo \"No tests\"",
     "dev": "wrangler pages dev .",
-    "deploy": "wrangler pages publish ."
+    "deploy": "wrangler pages deploy ."
   },
   "keywords": [],
   "author": "",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,2 +1,2 @@
-name = "artworkwindows"
+name = "artwork-windows"
 pages_build_output_dir = "."


### PR DESCRIPTION
## Summary
- rename Wrangler project to `artwork-windows`
- document that deployment uses `wrangler pages deploy`

## Testing
- `npm test`
- `npm run deploy` *(fails: CLOUDFLARE_API_TOKEN not set)*

------
https://chatgpt.com/codex/tasks/task_e_68c032469234832f8b4ef80cf6a05a67