### PR TITLE
Fix start button icon and cleanup stray build text

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
 
   <div class="taskbar">
     <button class="start-button" id="startBtn">
-      <img src="https://win98icons.alexmeub.com/icons/png/start.png" alt="" class="start-icon">Start
+      <span class="start-icon" aria-hidden="true"></span>Start
     </button>
     <div class="taskbar-item" id="galleryTab" style="display:none;">Gallery</div>
     <div class="taskbar-item" id="gamesTab" style="display:none;">Games</div>
@@ -248,7 +248,6 @@
       }
     });
 
-codex/enhance-old-windows-machine-theme-2hw4b6
     function initSnake() {
       const canvas = document.getElementById('snakeCanvas');
       const ctx = canvas.getContext('2d');

--- a/windows.css
+++ b/windows.css
@@ -97,7 +97,6 @@ body {
   font-size: 0.9rem;
   margin-top: 4px;
 }
-codex/enhance-old-windows-machine-theme-2hw4b6
 
 .games-list {
   list-style: none;
@@ -144,6 +143,13 @@ codex/enhance-old-windows-machine-theme-2hw4b6
   width: 20px;
   height: 20px;
   margin-right: 4px;
+  display: inline-block;
+  background:
+    linear-gradient(90deg, #00a4ef 50%, #f25022 50%),
+    linear-gradient(90deg, #ffb900 50%, #7fba00 50%);
+  background-size: 100% 50%;
+  background-position: 0 0, 0 100%;
+  background-repeat: no-repeat;
 }
 
 .start-button:active {


### PR DESCRIPTION
## Summary
- Replace external Start button image with CSS-based icon
- Remove stray build text that broke JavaScript and CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c034917378832f8c3d61e827acffb1